### PR TITLE
Switch to using `Consolas` as the default font

### DIFF
--- a/refterm_example_terminal.c
+++ b/refterm_example_terminal.c
@@ -862,7 +862,7 @@ RevertToDefaultFont(example_terminal *Terminal)
     wsprintfW(Terminal->RequestedFontName, L"%s", L"Courier New");
     Terminal->RequestedFontHeight = 25;
 #else
-    wsprintfW(Terminal->RequestedFontName, L"%s", L"Cascadia Mono");
+    wsprintfW(Terminal->RequestedFontName, L"%s", L"Consolas");
     Terminal->RequestedFontHeight = 17;
 #endif
 }


### PR DESCRIPTION
Rationale: Cascadia Mono is not available on default Win10 installs.

Closes #30