### PR TITLE
Fix: Potential uninitialized variable in `ParseEscape`

### DIFF
--- a/refterm_example_terminal.c
+++ b/refterm_example_terminal.c
@@ -229,7 +229,7 @@ static int ParseEscape(example_terminal *Terminal, source_buffer_range *Range, c
 
     wchar_t Command = 0;
     uint32_t ParamCount = 0;
-    uint32_t Params[8];
+    uint32_t Params[8] = {0};
     while((ParamCount < ArrayCount(Params)) && Range->Count)
     {
         char Token = PeekToken(Range, 0);


### PR DESCRIPTION
I realize this is a reference implementation and it doesn't necessarily
guarantee correctness or non-crashy behavior -- but it seems to me that
if the code encounters a short param list in the escpae sequence,
undefined/weird/non-deterministic behavior may result. This commit at
least makes it so that if there is a short escape param count, everything
defaults to 0.