### PR TITLE
Bugfix for IME support incorrectly decoding

### DIFF
--- a/refterm.c
+++ b/refterm.c
@@ -63,7 +63,7 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM WParam, LPA
         case WM_CHAR:
         case WM_SIZE:
         {
-            PostThreadMessage(RenderThreadID, Message, WParam, LParam);
+            PostThreadMessageW(RenderThreadID, Message, WParam, LParam);
         } break;
 
         default:

--- a/refterm_example_terminal.c
+++ b/refterm_example_terminal.c
@@ -1069,7 +1069,7 @@ static int IsUTF8Extension(char A)
 static void ProcessMessages(example_terminal *Terminal)
 {
     MSG Message;
-    while(PeekMessage(&Message, 0, 0, 0, PM_REMOVE))
+    while(PeekMessageW(&Message, 0, 0, 0, PM_REMOVE))
     {
         switch(Message.message)
         {


### PR DESCRIPTION
If you try to enter `konnichiha`, only the  `nn` as in the Japanese
hiragana ん (0x3093), turns into 0xB7. According to martins:

"for some codepages 0x81..0xfe bytes are DBCS lead bytes, where you then use extra bytes to decode codepoint"

is the leading theory. This is reproducible with other hiragana
like `wo`, but only when entered via IME and not via autohotkey.

As first noticed by `@Coda` in the Handmade Network Discord (@Core-l)