### PR TITLE
Hash advance and PostMessage fixes

### DIFF
--- a/refterm.c
+++ b/refterm.c
@@ -63,7 +63,7 @@ static LRESULT CALLBACK WindowProc(HWND Window, UINT Message, WPARAM WParam, LPA
         case WM_CHAR:
         case WM_SIZE:
         {
-            PostThreadMessage(RenderThreadID, Message, WParam, LParam);
+            PostThreadMessageW(RenderThreadID, Message, WParam, LParam);
         } break;
 
         default:
@@ -144,7 +144,7 @@ void WinMainCRTStartup()
            (Message.message == WM_QUIT) ||
            (Message.message == WM_SIZE))
         {
-            PostThreadMessage(RenderThreadID, Message.message, Message.wParam, Message.lParam);
+            PostThreadMessageW(RenderThreadID, Message.message, Message.wParam, Message.lParam);
         }
         else
         {

--- a/refterm_example_source_buffer.c
+++ b/refterm_example_source_buffer.c
@@ -1,23 +1,23 @@
 static source_buffer AllocateSourceBuffer(size_t DataSize)
 {
     source_buffer Result = {0};
-    
+
     SYSTEM_INFO Info;
     GetSystemInfo(&Info);
     Assert(IsPowerOfTwo(Info.dwAllocationGranularity));
-    
+
     // NOTE(casey): This has to be aligned to the allocation granularity otherwise the back-to-back buffer mapping might
     // not work.
     DataSize = (DataSize + Info.dwAllocationGranularity - 1) & ~(Info.dwAllocationGranularity - 1);
     HANDLE Section = CreateFileMapping (INVALID_HANDLE_VALUE, 0, PAGE_READWRITE, (DWORD)(DataSize >> 32), (DWORD)(DataSize & 0xffffffff), 0);
-    
+
  #ifdef MEM_REPLACE_PLACEHOLDER
     void* Placeholder1 = VirtualAlloc2 (0, 0,
                                         2 * DataSize, MEM_RESERVE | MEM_RESERVE_PLACEHOLDER, PAGE_NOACCESS,
                                         0, 0);
     VirtualFree (Placeholder1, DataSize, MEM_RELEASE | MEM_PRESERVE_PLACEHOLDER);
     void *Placeholder2 = ((char *)Placeholder1 + DataSize);
-    
+
     void *View1 = MapViewOfFile3 (Section, 0, Placeholder1, 0, DataSize, MEM_REPLACE_PLACEHOLDER, PAGE_READWRITE, 0, 0);
     void *View2 = MapViewOfFile3 (Section, 0, Placeholder2, 0, DataSize, MEM_REPLACE_PLACEHOLDER, PAGE_READWRITE, 0, 0);
     if(View1 && View2)
@@ -36,18 +36,18 @@ static source_buffer AllocateSourceBuffer(size_t DataSize)
             // TODO(casey): Harden this path to try multiple times
             void *View1 = (char *)MapViewOfFileEx(Section, FILE_MAP_ALL_ACCESS, 0, 0, DataSize, (void *)Offset);
             void *View2 = MapViewOfFileEx(Section, FILE_MAP_ALL_ACCESS, 0, 0, DataSize, ((char *)View1 + DataSize));
-            
+
             if(View1 && View2)
             {
                 Result.Data = View1;
                 Result.DataSize = DataSize;
                 break;
             }
-            
+
             if(View1) UnmapViewOfFile(View1);
             if(View2) UnmapViewOfFile(View2);
         }
-        
+
         if(!Result.Data)
         {
             MessageBoxW(0, L"Unable to allocate scrollback buffer with probing", L"Fatal error", MB_OK|MB_ICONSTOP);
@@ -55,7 +55,7 @@ static source_buffer AllocateSourceBuffer(size_t DataSize)
 #ifdef MEM_REPLACE_PLACEHOLDER
     }
 #endif
-    
+
     return Result;
 }
 
@@ -70,30 +70,30 @@ static int IsInBuffer(source_buffer *Buffer, size_t AbsoluteP)
 static source_buffer_range AdvanceRange(source_buffer_range Source, size_t ToAbsoluteP, size_t Count)
 {
     source_buffer_range Result = Source;
-    
+
     // NOTE(casey): Moving ranges backwards isn't safe, because you may slide off the beginning of the circular buffer.
     Assert(ToAbsoluteP >= Result.AbsoluteP);
-    
+
     Result.Data += ToAbsoluteP - Result.AbsoluteP;
     Result.AbsoluteP = ToAbsoluteP;
     Result.Count = Count;
-    
+
     return Result;
 }
 
 static source_buffer_range ConsumeCount(source_buffer_range Source, size_t Count)
 {
     source_buffer_range Result = Source;
-    
+
     if(Count > Result.Count)
     {
         Count = Result.Count;
     }
-    
+
     Result.Data += Count;
     Result.AbsoluteP += Count;
     Result.Count -= Count;
-    
+
     return Result;
 }
 
@@ -105,13 +105,13 @@ static source_buffer_range ReadSourceAt(source_buffer *Buffer, size_t AbsoluteP,
         Result.AbsoluteP = AbsoluteP;
         Result.Count = (Buffer->AbsoluteFilledSize - AbsoluteP);
         Result.Data = Buffer->Data + Buffer->DataSize + Buffer->RelativePoint - Result.Count;
-        
+
         if(Result.Count > Count)
         {
             Result.Count = Count;
         }
     }
-    
+
     return Result;
 }
 
@@ -125,7 +125,7 @@ static size_t GetCurrentAbsoluteP(source_buffer *Buffer)
 static source_buffer_range GetNextWritableRange(source_buffer *Buffer, size_t MaxCount)
 {
     Assert(Buffer->RelativePoint < Buffer->DataSize);
-    
+
     source_buffer_range Result = {0};
     Result.AbsoluteP = Buffer->AbsoluteFilledSize;
     Result.Count = Buffer->DataSize;
@@ -135,7 +135,7 @@ static source_buffer_range GetNextWritableRange(source_buffer *Buffer, size_t Ma
     {
         Result.Count = MaxCount;
     }
-    
+
     return Result;
 }
 
@@ -143,13 +143,13 @@ static void CommitWrite(source_buffer *Buffer, size_t Size)
 {
     Assert(Buffer->RelativePoint < Buffer->DataSize);
     Assert(Size <= Buffer->DataSize);
-    
+
     Buffer->RelativePoint += Size;
     Buffer->AbsoluteFilledSize += Size;
-    
+
     size_t WrappedRelative = Buffer->RelativePoint - Buffer->DataSize;
     Buffer->RelativePoint = (Buffer->RelativePoint >= Buffer->DataSize) ? WrappedRelative : Buffer->RelativePoint;
-    
+
     Assert(Buffer->RelativePoint < Buffer->DataSize);
 }
 
@@ -166,44 +166,45 @@ static char unsigned DefaultSeed[16] =
 static glyph_hash ComputeGlyphHash(size_t Count, char unsigned *At, char unsigned *Seedx16)
 {
     /* TODO(casey):
-    
+
       Consider and test some alternate hash designs.  The hash here
       was the simplest thing to type in, but it is not necessarily
-      the best hash for the job.  It may be that less AES rounds 
+      the best hash for the job.  It may be that less AES rounds
       would produce equivalently collision-free results for the
       problem space.  It may be that non-AES hashing would be
       better.  Some careful analysis would be nice.
     */
-      
+
     // TODO(casey): Does the result of a grapheme composition
     // depend on whether or not it was RTL or LTR?  Or are there
     // no fonts that ever get used in both directions, so it doesn't
     // matter?
-    
+
     // TODO(casey): Double-check exactly the pattern
     // we want to use for the hash here
-    
+
     glyph_hash Result = {0};
-    
+
     // TODO(casey): Should there be an IV?
     __m128i HashValue = _mm_cvtsi64_si128(Count);
     HashValue = _mm_xor_si128(HashValue, _mm_loadu_si128((__m128i *)Seedx16));
-    
+
     size_t ChunkCount = Count / 16;
     while(ChunkCount--)
     {
         __m128i In = _mm_loadu_si128((__m128i *)At);
-        
+        At += 16;
+
         HashValue = _mm_xor_si128(HashValue, In);
         HashValue = _mm_aesdec_si128(HashValue, _mm_setzero_si128());
         HashValue = _mm_aesdec_si128(HashValue, _mm_setzero_si128());
         HashValue = _mm_aesdec_si128(HashValue, _mm_setzero_si128());
         HashValue = _mm_aesdec_si128(HashValue, _mm_setzero_si128());
     }
-    
+
     size_t Overhang = Count % 16;
-    
-    
+
+
 #if 0
     __m128i In = _mm_loadu_si128((__m128i *)At);
 #else
@@ -219,9 +220,9 @@ static glyph_hash ComputeGlyphHash(size_t Count, char unsigned *At, char unsigne
     HashValue = _mm_aesdec_si128(HashValue, _mm_setzero_si128());
     HashValue = _mm_aesdec_si128(HashValue, _mm_setzero_si128());
     HashValue = _mm_aesdec_si128(HashValue, _mm_setzero_si128());
-    
+
     Result.Value = HashValue;
-    
+
     return Result;
 }
 
@@ -236,8 +237,7 @@ static glyph_hash ComputeHashForTileIndex(glyph_hash Tile0Hash, uint32_t TileInd
         HashValue = _mm_aesdec_si128(HashValue, _mm_setzero_si128());
         HashValue = _mm_aesdec_si128(HashValue, _mm_setzero_si128());
     }
-    
+
     glyph_hash Result = {HashValue};
     return Result;
 }
-    


### PR DESCRIPTION
Two bug fixes from the V3 branch that can be merged back to the main branch already.

One is that the hash function wasn't advancing its pointer (it never gets passed things longer than 15 bytes, so there is no way to know, but, if you _were_ to do it, this fixes the bug you would encounter). The second is that the non-Unicode Win32 API was called in two places which called problems for IMEs.

\- Casey