### PR TITLE
fix CellCount calculation

### DIFF
--- a/refterm_example_d3d11.c
+++ b/refterm_example_d3d11.c
@@ -393,7 +393,7 @@ static void RendererDraw(example_terminal *Terminal, uint32_t Width, uint32_t He
         Renderer->CurrentHeight = Height;
     }
 
-    uint32_t CellCount = Renderer->CurrentWidth*Renderer->CurrentHeight;
+    uint32_t CellCount = Term->DimX*Term->DimY;
     if(Renderer->MaxCellCount < CellCount)
     {
         SetD3D11MaxCellCount(Renderer, CellCount);


### PR DESCRIPTION
The cell count used to allocate the array of cells for the shader is using the pixel size rather than the cell size. This results in allocating an array of cells that is W*H times bigger than required (where W/H is the pixel size of one cell). For example on my machine I need about 10K cells but refterm is allocating 2 million.

The correct cell count calculation can also be seen further down in the file when the cell data is memcopied.
